### PR TITLE
Add cost comparison chart

### DIFF
--- a/FinalFRP/frontend/README.md
+++ b/FinalFRP/frontend/README.md
@@ -2,6 +2,9 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+### Cost Comparison Chart
+After running a calculation, a bar chart compares the total cost for each returned route. Make sure `react-chartjs-2` and `chart.js` are installed with `npm install`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/FinalFRP/frontend/package-lock.json
+++ b/FinalFRP/frontend/package-lock.json
@@ -12,8 +12,10 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "chart.js": "^4.4.1",
         "leaflet": "^1.9.4",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^19.1.0",
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^6.30.1",
@@ -2960,6 +2962,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -5551,6 +5559,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-types": {
@@ -13823,6 +13843,16 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dev-utils": {

--- a/FinalFRP/frontend/package.json
+++ b/FinalFRP/frontend/package.json
@@ -12,6 +12,8 @@
     "react-dom": "^19.1.0",
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^6.30.1",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/FinalFRP/frontend/src/components/CostComparisonChart.js
+++ b/FinalFRP/frontend/src/components/CostComparisonChart.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Bar } from 'react-chartjs-2';
+import {
+  Chart,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend
+} from 'chart.js';
+
+Chart.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const CostComparisonChart = ({ routes = [] }) => {
+  if (!routes.length) return null;
+
+  const data = {
+    labels: routes.map((r) => r.name),
+    datasets: [
+      {
+        label: 'Total Cost (USD)',
+        data: routes.map((r) => r.estimatedCost),
+        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: true,
+        ticks: {
+          callback: (value) => `$${value}`,
+        },
+      },
+    },
+  };
+
+  return (
+    <div style={{ height: '300px' }}>
+      <Bar data={data} options={options} />
+    </div>
+  );
+};
+
+export default CostComparisonChart;

--- a/FinalFRP/frontend/src/components/FuelRouteApp.js
+++ b/FinalFRP/frontend/src/components/FuelRouteApp.js
@@ -1,6 +1,7 @@
 //frontend/src/components/FuelRouteApp.js - ERROR FIXES ONLY
 import React, { useState, useEffect } from 'react';
 import RouteMap from './RouteMap';
+import CostComparisonChart from './CostComparisonChart';
 import './RouteMap.css';
 
 // API Service - inlined to avoid external imports
@@ -1363,6 +1364,12 @@ const validateLocationBasic = (location, fieldName) => {
                       </div>
                     ))}
                   </div>
+                </div>
+              )}
+
+              {result?.routeOptions && (
+                <div className="bg-white rounded-lg shadow-md p-6">
+                  <CostComparisonChart routes={result.routeOptions} />
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- install `react-chartjs-2` and `chart.js`
- create `CostComparisonChart` for bar chart visualizations
- display cost comparison chart in `FuelRouteApp`
- document chart feature

## Testing
- `npm test --silent -- --passWithNoTests` in `backend`
- `npm test --silent -- --watchAll=false --passWithNoTests` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68806dac06208323b9a8d1ff83f8877a