### PR TITLE
Add coastal route fallback

### DIFF
--- a/FinalFRP/frontend/src/components/RouteMap.js
+++ b/FinalFRP/frontend/src/components/RouteMap.js
@@ -4,6 +4,7 @@ import { MapContainer, TileLayer, Marker, Popup, Polyline, LayersControl, Featur
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './RouteMap.css';
+import coastalRoutes from '../services/coastalRoutes';
 
 // Fix default markers (Leaflet + React issue)
 delete L.Icon.Default.prototype._getIconUrl;
@@ -158,6 +159,94 @@ const decodePolyline = (encoded) => {
   return coordinates;
 };
 
+// Retrieve coastal waypoints from the dataset when available
+const getCoastalWaypoints = (origin, destination) => {
+  const key = `${origin}-${destination}`;
+  const reverseKey = `${destination}-${origin}`;
+
+  if (coastalRoutes[key] && coastalRoutes[key].waypoints.length > 0) {
+    return coastalRoutes[key].waypoints;
+  }
+  if (coastalRoutes[reverseKey] && coastalRoutes[reverseKey].waypoints.length > 0) {
+    return [...coastalRoutes[reverseKey].waypoints].reverse();
+  }
+  return null;
+};
+
+// Generic coastal paths used when no specific route exists
+const coastalPaths = {
+  west: [
+    [32.7157, -117.1611],
+    [33.7292, -118.2620],
+    [36.6002, -121.8947],
+    [39.1612, -123.7881],
+    [43.3504, -124.3738],
+    [46.2816, -124.0833],
+    [47.6062, -122.3321]
+  ],
+  gulf: [
+    [29.7050, -95.0030],
+    [29.4724, -94.0572],
+    [29.9511, -90.0715],
+    [30.6944, -88.0431],
+    [27.9506, -82.4572]
+  ],
+  east: [
+    [25.7617, -80.1918],
+    [30.3322, -81.6557],
+    [32.0835, -81.0998],
+    [33.8734, -78.8808],
+    [35.2271, -75.5449],
+    [36.8468, -76.2852],
+    [40.7128, -74.0060],
+    [42.3601, -71.0589]
+  ]
+};
+
+// Build a simple coastal fallback between two coordinates
+const generateCoastalFallback = (start, end) => {
+  if (!start || !end) return [];
+
+  const paths = Object.values(coastalPaths);
+
+  const calcDist = (a, b) => L.latLng(a[0], a[1]).distanceTo(L.latLng(b[0], b[1]));
+
+  let bestPath = paths[0];
+  let bestScore = Infinity;
+
+  paths.forEach(path => {
+    const score = calcDist(start, path[0]) + calcDist(end, path[path.length - 1]);
+    if (score < bestScore) {
+      bestScore = score;
+      bestPath = path;
+    }
+  });
+
+  const nearestIndex = (coords, path) => {
+    let idx = 0;
+    let min = Infinity;
+    path.forEach((p, i) => {
+      const d = calcDist(coords, p);
+      if (d < min) {
+        min = d;
+        idx = i;
+      }
+    });
+    return idx;
+  };
+
+  const startIdx = nearestIndex(start, bestPath);
+  const endIdx = nearestIndex(end, bestPath);
+
+  let slice = bestPath.slice(Math.min(startIdx, endIdx), Math.max(startIdx, endIdx) + 1);
+  if (startIdx > endIdx) slice = slice.reverse();
+
+  slice[0] = start;
+  slice[slice.length - 1] = end;
+
+  return slice;
+};
+
 // Major US ports and hubs with coordinates
 const locations = {
   'Houston, TX': [29.7604, -95.3698],
@@ -264,13 +353,25 @@ useEffect(() => {
         routePath = route.waypoints;
       }
 
-      // Fallback to a simple curved path if nothing else is available
+      // Fallback handling for missing waypoints
       if (routePath.length === 0) {
         const originCoords = locations[route.routePath?.[0] || origin];
         const destCoords = locations[route.routePath?.[route.routePath.length - 1] || destination];
 
-        if (originCoords && destCoords) {
-          const primaryMode = route.transportModes?.[0] || 'truck';
+        const primaryMode = route.transportModes?.[0] || 'truck';
+
+        if (primaryMode === 'ship') {
+          // Try to use predefined coastal waypoints
+          routePath = getCoastalWaypoints(origin, destination) || [];
+
+          // If none available, generate a generic coastal fallback
+          if (routePath.length === 0 && originCoords && destCoords) {
+            routePath = generateCoastalFallback(originCoords, destCoords);
+          }
+        }
+
+        // Final fallback to curved path
+        if (routePath.length === 0 && originCoords && destCoords) {
           routePath = generateCurvedPath(originCoords, destCoords, primaryMode);
         }
       }

--- a/FinalFRP/frontend/src/services/coastalRoutes.js
+++ b/FinalFRP/frontend/src/services/coastalRoutes.js
@@ -1,0 +1,111 @@
+const shippingRoutes = {
+  // West Coast
+  'Los Angeles, CA-San Francisco/Oakland, CA': {
+    waypoints: [
+      [33.7292, -118.2620],
+      [35.3606, -120.8493],
+      [36.6002, -121.8947],
+      [37.8044, -122.2712]
+    ]
+  },
+  'Los Angeles, CA-Seattle, WA': {
+    waypoints: [
+      [33.7292, -118.2620],
+      [36.6002, -121.8947],
+      [39.1612, -123.7881],
+      [43.3504, -124.3738],
+      [46.2816, -124.0833],
+      [47.6062, -122.3321]
+    ]
+  },
+  'Los Angeles, CA-Portland, OR': {
+    waypoints: [
+      [33.7292, -118.2620],
+      [36.6002, -121.8947],
+      [39.1612, -123.7881],
+      [43.3504, -124.3738],
+      [45.5152, -122.6784]
+    ]
+  },
+  // Gulf Coast
+  'Houston, TX-New Orleans, LA': {
+    waypoints: [
+      [29.7050, -95.0030],
+      [29.4724, -94.0572],
+      [29.9355, -90.0572]
+    ]
+  },
+  'Houston, TX-Mobile, AL': {
+    waypoints: [
+      [29.7050, -95.0030],
+      [29.4724, -94.0572],
+      [30.6944, -88.0431]
+    ]
+  },
+  // Atlantic Coast
+  'New York/NJ-Norfolk, VA': {
+    waypoints: [
+      [40.7128, -74.0060],
+      [39.3558, -74.4208],
+      [37.5407, -75.9665],
+      [36.8468, -76.2852]
+    ]
+  },
+  'Norfolk, VA-Savannah, GA': {
+    waypoints: [
+      [36.8468, -76.2852],
+      [35.2271, -75.5449],
+      [33.8734, -78.8808],
+      [32.0835, -81.0998]
+    ]
+  },
+  'Miami, FL-Norfolk, VA': {
+    waypoints: [
+      [25.7617, -80.1918],
+      [30.3322, -81.6557],
+      [32.0835, -81.0998],
+      [33.8734, -78.8808],
+      [35.2271, -75.5449],
+      [36.8468, -76.2852]
+    ]
+  },
+  // Other routes
+  'New Orleans, LA-Mobile, AL': {
+    waypoints: []
+  },
+  'Houston, TX-Tampa Bay, FL': {
+    waypoints: []
+  },
+  'New York/NJ-Philadelphia, PA': {
+    waypoints: []
+  },
+  'Savannah, GA-Jacksonville, FL': {
+    waypoints: []
+  },
+  'Jacksonville, FL-Miami, FL': {
+    waypoints: []
+  },
+  'Los Angeles, CA-Long Beach, CA': {
+    waypoints: []
+  },
+  'San Francisco/Oakland, CA-Seattle, WA': {
+    waypoints: []
+  },
+  'Seattle, WA-Portland, OR': {
+    waypoints: []
+  },
+  'Los Angeles, CA-Houston, TX': {
+    waypoints: []
+  },
+  'Los Angeles, CA-New Orleans, LA': {
+    waypoints: []
+  },
+  'Seattle, WA-New York/NJ': {
+    waypoints: []
+  },
+  'Chicago, IL-Duluth-Superior, MN/WI': {
+    waypoints: []
+  }
+};
+
+export default shippingRoutes;


### PR DESCRIPTION
## Summary
- add ship routes dataset to the frontend
- generate coastal fallback paths when ship waypoints are missing
- prefer coastal routes over curved paths so polylines stay over water

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68808f3ba4548323a10fd352665f8700