### PR TITLE
Enhance cost comparison chart

### DIFF
--- a/FinalFRP/frontend/src/components/CostComparisonChart.js
+++ b/FinalFRP/frontend/src/components/CostComparisonChart.js
@@ -30,9 +30,25 @@ const CostComparisonChart = ({ routes = [] }) => {
   const options = {
     responsive: true,
     maintainAspectRatio: false,
+    plugins: {
+      title: {
+        display: true,
+        text: 'Route Cost Comparison',
+      },
+    },
     scales: {
+      x: {
+        title: {
+          display: true,
+          text: 'Route Options',
+        },
+      },
       y: {
         beginAtZero: true,
+        title: {
+          display: true,
+          text: 'Total Cost (USD)',
+        },
         ticks: {
           callback: (value) => `$${value}`,
         },
@@ -43,6 +59,9 @@ const CostComparisonChart = ({ routes = [] }) => {
   return (
     <div style={{ height: '300px' }}>
       <Bar data={data} options={options} />
+      <p className="text-center text-gray-600 text-sm mt-2">
+        Bars show total project cost per route.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add chart title and axis titles to CostComparisonChart
- show a caption explaining the bars represent total project cost

## Testing
- `CI=true npm test --silent -- --passWithNoTests` in `frontend`
- `CI=true npm test --silent -- --passWithNoTests` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6881c04457d08323bf587b9a37ae4e2b