### PR TITLE
Add password validation with tests

### DIFF
--- a/FinalFRP/frontend/src/components/Login.js
+++ b/FinalFRP/frontend/src/components/Login.js
@@ -2,6 +2,15 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import './Login.css';
 
+export const isValidPassword = (password) => {
+  return (
+    typeof password === 'string' &&
+    password.length >= 6 &&
+    /\d/.test(password) &&
+    /[^A-Za-z0-9]/.test(password)
+  );
+};
+
 const Login = () => {
   const [formData, setFormData] = useState({
     name: '',
@@ -53,6 +62,11 @@ const Login = () => {
         if (existingUser) {
           setMessage('User already exists! Please use the Login option or try a different name/email.');
         } else {
+          if (!isValidPassword(formData.password)) {
+            setMessage('Password must be at least 6 characters and include a number and special character');
+            setIsLoading(false);
+            return;
+          }
           // Register new user
           const newUser = { ...formData, id: Date.now(), searchCount: 0, isSubscribed: false };
           storedUsers.push(newUser);

--- a/FinalFRP/frontend/src/components/__tests__/Login.test.js
+++ b/FinalFRP/frontend/src/components/__tests__/Login.test.js
@@ -1,0 +1,19 @@
+import { isValidPassword } from '../Login';
+
+describe('isValidPassword', () => {
+  test('rejects passwords that are too short', () => {
+    expect(isValidPassword('a1!')).toBe(false);
+  });
+
+  test('rejects passwords without digits', () => {
+    expect(isValidPassword('abcdef!')).toBe(false);
+  });
+
+  test('rejects passwords without special characters', () => {
+    expect(isValidPassword('abcdef1')).toBe(false);
+  });
+
+  test('accepts valid passwords', () => {
+    expect(isValidPassword('abc123!')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `isValidPassword` helper to Login component
- validate passwords during sign up
- add unit tests for password validation

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68827bdc52d4832398ba387b6e4323bf