### PR TITLE
Add coastal waypoint routing logic

### DIFF
--- a/FinalFRP/backend/__tests__/coastalFallback.test.js
+++ b/FinalFRP/backend/__tests__/coastalFallback.test.js
@@ -1,0 +1,20 @@
+const { generateCoastalFallback } = require('../routes/routingRoutes');
+const coastalRoutes = require('../data/coastalRoutes.json');
+
+describe('coastal route utilities', () => {
+  test('generateCoastalFallback returns path starting and ending at provided points', () => {
+    const start = [29.7050, -95.0030]; // Houston
+    const end = [29.9511, -90.0715];  // New Orleans
+    const path = generateCoastalFallback(start, end);
+    expect(Array.isArray(path)).toBe(true);
+    expect(path.length).toBeGreaterThan(2);
+    expect(path[0]).toEqual(start);
+    expect(path[path.length - 1]).toEqual(end);
+  });
+
+  test('coastalRoutes dataset has waypoints for known route', () => {
+    const key = 'Houston, TX-New Orleans, LA';
+    expect(coastalRoutes[key]).toBeDefined();
+    expect(coastalRoutes[key].waypoints.length).toBeGreaterThan(0);
+  });
+});

--- a/FinalFRP/backend/data/coastalRoutes.json
+++ b/FinalFRP/backend/data/coastalRoutes.json
@@ -1,0 +1,22 @@
+{
+  "Los Angeles, CA-San Francisco/Oakland, CA": {"waypoints": [[33.7292, -118.2620], [35.3606, -120.8493], [36.6002, -121.8947], [37.8044, -122.2712]]},
+  "Los Angeles, CA-Seattle, WA": {"waypoints": [[33.7292, -118.2620], [36.6002, -121.8947], [39.1612, -123.7881], [43.3504, -124.3738], [46.2816, -124.0833], [47.6062, -122.3321]]},
+  "Los Angeles, CA-Portland, OR": {"waypoints": [[33.7292, -118.2620], [36.6002, -121.8947], [39.1612, -123.7881], [43.3504, -124.3738], [45.5152, -122.6784]]},
+  "Houston, TX-New Orleans, LA": {"waypoints": [[29.7050, -95.0030], [29.4724, -94.0572], [29.9355, -90.0572]]},
+  "Houston, TX-Mobile, AL": {"waypoints": [[29.7050, -95.0030], [29.4724, -94.0572], [30.6944, -88.0431]]},
+  "New York/NJ-Norfolk, VA": {"waypoints": [[40.7128, -74.0060], [39.3558, -74.4208], [37.5407, -75.9665], [36.8468, -76.2852]]},
+  "Norfolk, VA-Savannah, GA": {"waypoints": [[36.8468, -76.2852], [35.2271, -75.5449], [33.8734, -78.8808], [32.0835, -81.0998]]},
+  "Miami, FL-Norfolk, VA": {"waypoints": [[25.7617, -80.1918], [30.3322, -81.6557], [32.0835, -81.0998], [33.8734, -78.8808], [35.2271, -75.5449], [36.8468, -76.2852]]},
+  "New Orleans, LA-Mobile, AL": {"waypoints": []},
+  "Houston, TX-Tampa Bay, FL": {"waypoints": []},
+  "New York/NJ-Philadelphia, PA": {"waypoints": []},
+  "Savannah, GA-Jacksonville, FL": {"waypoints": []},
+  "Jacksonville, FL-Miami, FL": {"waypoints": []},
+  "Los Angeles, CA-Long Beach, CA": {"waypoints": []},
+  "San Francisco/Oakland, CA-Seattle, WA": {"waypoints": []},
+  "Seattle, WA-Portland, OR": {"waypoints": []},
+  "Los Angeles, CA-Houston, TX": {"waypoints": [[33.7292, -118.2620], [23.033, -109.7], [15.0, -96.0], [9.0, -79.6], [9.1, -79.8], [9.3, -79.9], [21.5, -86.9], [25.3, -90.0], [27.0, -94.0], [29.7050, -95.0030]]},
+  "Los Angeles, CA-New Orleans, LA": {"waypoints": [[33.7292, -118.2620], [23.033, -109.7], [15.0, -96.0], [9.0, -79.6], [9.1, -79.8], [9.3, -79.9], [21.5, -86.9], [26.0, -90.0], [28.0, -91.0], [29.9355, -90.0572]]},
+  "Seattle, WA-New York/NJ": {"waypoints": []},
+  "Chicago, IL-Duluth-Superior, MN/WI": {"waypoints": []}
+}


### PR DESCRIPTION
## Summary
- add coastalRoutes JSON dataset for shipping waypoints
- build ship routes in `routingRoutes` using waypoint data or a coastal fallback
- export fallback function and add unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68827be8a7548323b182eb0e5103b955