### PR TITLE
Remove price capping in commodity price flow

### DIFF
--- a/FinalFRP/backend/controllers/routeController.js
+++ b/FinalFRP/backend/controllers/routeController.js
@@ -487,22 +487,10 @@ function calculateRealisticFallback(volume, distance, mode, fuelType) {
 function getCommodityCost(fuelType, volume, openaiPrice = null) {
   let basePrice = commodityPrices[fuelType] || commodityPrices.gasoline;
   
-  // If OpenAI provided a price, use it but cap it at reasonable limits
+  // If OpenAI provided a price, use it directly
   if (openaiPrice && openaiPrice > 0) {
-    // Cap prices at reasonable maximums to prevent unrealistic costs
-    const maxPrices = {
-      hydrogen: 3500,   // Cap hydrogen at $3500/tonne
-      methanol: 600,    // Cap methanol at $600/tonne
-      ammonia: 700,     // Cap ammonia at $700/tonne
-      gasoline: 800,    // Cap gasoline at $800/tonne
-      diesel: 850,      // Cap diesel at $850/tonne
-      ethanol: 700      // Cap ethanol at $700/tonne
-    };
-    
-    const maxPrice = maxPrices[fuelType] || basePrice * 1.5;
-    basePrice = Math.min(openaiPrice, maxPrice);
-    
-    console.log(`💰 Using OpenAI price: $${openaiPrice}/tonne, capped at: $${basePrice}/tonne`);
+    basePrice = openaiPrice;
+    console.log(`💰 Using OpenAI price: $${openaiPrice}/tonne`);
   }
   
   // Add realistic market fluctuation (±3%)

--- a/FinalFRP/backend/services/openaiService.js
+++ b/FinalFRP/backend/services/openaiService.js
@@ -125,30 +125,11 @@ Respond with ONLY a JSON object in this exact format with NO additional text:
         console.log('🤖 PARSED RESULT:', result);
 
         console.log(`✅ OpenAI realistic price response for ${fuelType}:`, result);
-        
-        // Validate the price is within reasonable bounds
-        const reasonablePrices = {
-          hydrogen: { min: 1500, max: 3500 },
-          methanol: { min: 300, max: 600 },
-          ammonia: { min: 350, max: 700 },
-          gasoline: { min: 600, max: 800 },
-          diesel: { min: 650, max: 850 }
-        };
-        
-        const bounds = reasonablePrices[fuelType] || { min: 500, max: 1000 };
-        
-        // Cap the price within reasonable bounds
+
+        // Validate and return the price directly
         let finalPrice = result.price;
         if (typeof finalPrice !== 'number' || isNaN(finalPrice)) {
           throw new Error('Invalid price returned from OpenAI');
-        }
-        
-        if (finalPrice < bounds.min) {
-          finalPrice = bounds.min;
-          console.log(`⚠️ Price too low, adjusted to minimum: $${finalPrice}`);
-        } else if (finalPrice > bounds.max) {
-          finalPrice = bounds.max;
-          console.log(`⚠️ Price too high, adjusted to maximum: $${finalPrice}`);
         }
         
         return {


### PR DESCRIPTION
## Summary
- simplify OpenAI price handling to use returned price directly
- remove capping logic from commodity cost calculation
- update console messages accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688290460fdc8323945ac64943bf847d