### PR TITLE
Expose OpenAI cache timeout via env var

### DIFF
--- a/FinalFRP/README.md
+++ b/FinalFRP/README.md
@@ -12,3 +12,8 @@
 - 🤖 Integrate with AI models via Ollama for deeper insights
 - ⚙️ Compare routes and optimize decision-making
 - 🎯 Choose lowest cost or shortest distance preference
+
+## Configuration
+
+Set `OPENAI_PRICE_CACHE_MS` to control how long fuel price estimates are cached.
+The default is 900000 (15 minutes). Use `0` to disable caching entirely.


### PR DESCRIPTION
## Summary
- make price cache timeout configurable via `OPENAI_PRICE_CACHE_MS`
- document the new environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882904781808323adb6b6f079d1b372