### PR TITLE
Fix distance estimate fallback

### DIFF
--- a/FinalFRP/backend/services/routingService.js
+++ b/FinalFRP/backend/services/routingService.js
@@ -111,8 +111,12 @@ function estimateDistanceFromCoordinates(origin, destination, transportMode) {
     ship: 1.4      // Coastal routing
   };
   
-  const adjustedDistance = Math.round(straightLineDistance * (modeMultipliers[transportMode] || 1.15));
-  console.log(`📏 Estimated distance: ${adjustedDistance} miles (${straightLineDistance.toFixed(0)} miles direct × ${modeMultipliers[transportMode] || 1.15})`);
+  const adjustedDistance = Math.round(
+    straightLineDistance * (modeMultipliers[transportMode] || 1.0)
+  );
+  console.log(
+    `📏 Estimated distance: ${adjustedDistance} miles (${straightLineDistance.toFixed(0)} miles direct × ${modeMultipliers[transportMode] || 1.0})`
+  );
   
   return adjustedDistance;
 }


### PR DESCRIPTION
## Summary
- tweak fallback multiplier for estimated distances

## Testing
- `npm test` in `backend`
- `CI=true npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6883209966ec832394be0493bf2a517c