### PR TITLE
Add script for OpenAI distance calculation

### DIFF
--- a/FinalFRP/README.md
+++ b/FinalFRP/README.md
@@ -17,3 +17,7 @@
 
 Set `OPENAI_PRICE_CACHE_MS` to control how long fuel price estimates are cached.
 The default is 900000 (15 minutes). Use `0` to disable caching entirely.
+
+## Distance Script
+
+Use `node backend/scripts/calculate-distances.js "Origin" "Destination" truck rail` to request OpenAI-generated distances for two modes.

--- a/FinalFRP/backend/scripts/calculate-distances.js
+++ b/FinalFRP/backend/scripts/calculate-distances.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+const openaiService = require('../services/openaiService');
+
+if (!openaiService || !openaiService.isAvailable) {
+  console.error('OpenAI service not available.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+if (args.length < 4) {
+  console.log('Usage: node calculate-distances.js <origin> <destination> <mode1> <mode2>');
+  process.exit(1);
+}
+
+const [origin, destination, mode1, mode2] = args;
+
+async function run() {
+  try {
+    const result1 = await openaiService.calculateDistanceWithModeAdjustment(origin, destination, mode1);
+    const result2 = await openaiService.calculateDistanceWithModeAdjustment(origin, destination, mode2);
+    console.log(JSON.stringify({ origin, destination, [mode1]: result1, [mode2]: result2 }, null, 2));
+  } catch (err) {
+    console.error('Distance calculation failed:', err.message);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- add a helper script to fetch route distances via OpenAI
- document the script in README

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68833027b9d48323ac4d653ea58d7590