### PR TITLE
Enhance rail route map paths

### DIFF
--- a/FinalFRP/backend/services/railNetworkService.js
+++ b/FinalFRP/backend/services/railNetworkService.js
@@ -125,10 +125,15 @@ class RailNetworkService {
       
       // First check the consolidated distance matrix
       let distance = getDistance(origin, destination, 'rail');
-      
+
+      // Attempt to get detailed path using network routing
+      const networkRoute = this.findRailPath(origin, destination);
+
       if (distance) {
         console.log(`✅ Rail distance from matrix: ${distance} miles`);
-        return this.createRailRouteResponse(origin, destination, distance, [origin, destination], 'distance_matrix');
+        const path = networkRoute ? networkRoute.route_path : [origin, destination];
+        const method = networkRoute ? 'distance_matrix_network_path' : 'distance_matrix';
+        return this.createRailRouteResponse(origin, destination, distance, path, method);
       }
 
       // Fallback to local rail distances if not in main matrix
@@ -138,13 +143,14 @@ class RailNetworkService {
 
       if (distance) {
         console.log(`✅ Rail distance from local data: ${distance} miles`);
-        return this.createRailRouteResponse(origin, destination, distance, [origin, destination], 'local_rail_data');
+        const path = networkRoute ? networkRoute.route_path : [origin, destination];
+        const method = networkRoute ? 'local_rail_data_network_path' : 'local_rail_data';
+        return this.createRailRouteResponse(origin, destination, distance, path, method);
       }
 
-      // Try network routing
-      const route = this.findRailPath(origin, destination);
-      if (route) {
-        return route;
+      // Use network routing if available
+      if (networkRoute) {
+        return networkRoute;
       }
 
       // No rail route available

--- a/FinalFRP/frontend/src/components/RouteMap.js
+++ b/FinalFRP/frontend/src/components/RouteMap.js
@@ -5,6 +5,7 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import './RouteMap.css';
 import coastalRoutes from '../services/coastalRoutes';
+import railRoutes from '../services/railRoutes';
 
 // Fix default markers (Leaflet + React issue)
 delete L.Icon.Default.prototype._getIconUrl;
@@ -304,9 +305,18 @@ const RouteMap = ({
       }
       // Add more routes as needed
     };
-  
+
   const routeKey = `${origin}-${destination}`;
   const reverseKey = `${destination}-${origin}`;
+
+  if (transportMode === 'rail') {
+    if (railRoutes[routeKey] && railRoutes[routeKey].waypoints.length > 0) {
+      return railRoutes[routeKey].waypoints;
+    }
+    if (railRoutes[reverseKey] && railRoutes[reverseKey].waypoints.length > 0) {
+      return [...railRoutes[reverseKey].waypoints].reverse();
+    }
+  }
   
   if (routeWaypoints[routeKey] && routeWaypoints[routeKey][transportMode]) {
     return routeWaypoints[routeKey][transportMode];
@@ -357,6 +367,11 @@ useEffect(() => {
           if (routePath.length === 0 && originCoords && destCoords) {
             routePath = generateCoastalFallback(originCoords, destCoords);
           }
+        }
+
+        // Try predefined rail or truck paths
+        if (routePath.length === 0) {
+          routePath = getRealisticRoutePath(origin, destination, primaryMode);
         }
 
         // Final fallback to curved path

--- a/FinalFRP/frontend/src/components/RouteMap.js
+++ b/FinalFRP/frontend/src/components/RouteMap.js
@@ -258,7 +258,11 @@ const locations = {
   'Chicago, IL': [41.8781, -87.6298],
   'St. Louis, MO': [38.6270, -90.1994],
   'Memphis, TN': [35.1495, -90.0490],
-  'Duluth-Superior, MN/WI': [46.7867, -92.1005]
+  'Duluth-Superior, MN/WI': [46.7867, -92.1005],
+  'Dallas, TX': [32.7767, -96.7970],
+  'San Antonio, TX': [29.4241, -98.4936],
+  'Detroit, MI': [42.3314, -83.0458],
+  'Milwaukee, WI': [43.0389, -87.9065]
 };
 
 const RouteMap = ({ 

--- a/FinalFRP/frontend/src/services/railRoutes.js
+++ b/FinalFRP/frontend/src/services/railRoutes.js
@@ -1,0 +1,39 @@
+const railRoutes = {
+  'Los Angeles, CA-Chicago, IL': {
+    waypoints: [
+      [34.0522, -118.2437],
+      [36.7783, -119.4179],
+      [41.8781, -87.6298]
+    ]
+  },
+  'Houston, TX-Chicago, IL': {
+    waypoints: [
+      [29.7604, -95.3698],
+      [35.1495, -90.0490],
+      [41.8781, -87.6298]
+    ]
+  },
+  'Chicago, IL-New Orleans, LA': {
+    waypoints: [
+      [41.8781, -87.6298],
+      [38.6270, -90.1994],
+      [35.1495, -90.0490],
+      [29.9511, -90.0715]
+    ]
+  },
+  'Seattle, WA-Chicago, IL': {
+    waypoints: [
+      [47.6062, -122.3321],
+      [45.5152, -122.6784],
+      [41.8781, -87.6298]
+    ]
+  },
+  'New York/NJ-Chicago, IL': {
+    waypoints: [
+      [40.7128, -74.0060],
+      [41.8781, -87.6298]
+    ]
+  }
+};
+
+export default railRoutes;


### PR DESCRIPTION
## Summary
- include network path details in backend rail route responses
- add predefined rail routes dataset
- display realistic rail paths on maps using new data

## Testing
- `npm test` in `backend`
- `npm test -- -w 1` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6883372c95cc832397ecaed5fd0a2b48